### PR TITLE
Add initial commit for github action

### DIFF
--- a/.github/workflows/make_book.yml
+++ b/.github/workflows/make_book.yml
@@ -1,0 +1,51 @@
+name: deploy-book
+
+# Only run this when the master branch changes
+on:
+  push:
+    branches:
+    - jupyterbook
+    # If your git repository has the Jupyter Book within some-subfolder next to
+    # unrelated files, you can make this run only if a file within that specific
+    # folder has been modified.
+    #
+    # paths:
+    # - some-subfolder/**
+
+# This job installs dependencies, builds the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: psf/black@stable
+      with:
+        options: ""
+        jupyter: true
+
+    # Install dependencies
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Install jupyter book
+      run: |
+        pip install -U jupyter-book
+
+    # Build the book
+    - name: Build the book
+      run: |
+        jupyter-book build .
+
+    # Push the book's HTML to github-pages
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./_build/html

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,42 @@
+#######################################################################################
+# Book settings
+title: Differential privacy # The title of the book. Will be placed in the left navbar.
+author: Lucas Rosenblatt, Bernease ???, Andrii Stadnik, Anastasia Holovenko, Taras Rumerzhak # The author of the book
+copyright                   : "2022"  # Copyright year to be placed in the footer
+# logo                        : ""  # A path to the book logo
+# Patterns to skip when building the book. Can be glob-style (e.g. "*skip.ipynb")
+# exclude_patterns            : [_build, Thumbs.db, .DS_Store, "**.ipynb_checkpoints"]
+# Auto-exclude files not in the toc
+only_build_toc_files        : true
+
+#######################################################################################
+# Execution settings
+execute:
+  timeout: 100
+  execute_notebooks         : force  # Whether to execute notebooks at build time. Must be one of ("auto", "force", "cache", "off")
+  run_in_temp               : false # If `True`, then a temporary directory will be created and used as the command working directory (cwd),
+                                    # otherwise the notebook's parent directory will be the cwd.
+  allow_errors              : false
+  stderr_output             : show  # One of 'show', 'remove', 'remove-warn', 'warn', 'error', 'severe'
+
+#######################################################################################
+# HTML-specific settings
+html:
+  favicon                   : ""  # A path to a favicon image
+  use_edit_page_button      : false  # Whether to add an "edit this page" button to pages. If `true`, repository information in repository: must be filled in
+  use_repository_button     : true  # Whether to add a link to your repository button
+  use_issues_button         : true  # Whether to add an "open an issue" button
+
+repository:
+  url                       : https://github.com/DataResponsibly/SynRD  # The URL to your book's repository
+  # path_to_book              : "book"  # A path to your book's folder, relative to the repository root.
+  # branch                    : main  # Which branch of the repository should be used when creating links
+
+launch_buttons:
+  colab_url: "https://colab.research.google.com"
+
+# https://jupyterbook.org/en/stable/interactive/interactive.html#plotly
+sphinx:
+  config:
+    html_js_files:
+    - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,0 +1,11 @@
+# Table of contents
+# Learn more at https://jupyterbook.org/customize/toc.html
+
+format: jb-book
+root: README
+parts:
+  # - caption: Simulator
+  #   chapters:
+  - caption: Sample notebook
+    chapters:
+    - file: papers/generate_figures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+pandas
+numpy
+scikit-learn
+git+https://github.com/ryan112358/private-pgm.git
+smartnoise-synth
+diffprivlib
+rpy2
+pathlib


### PR DESCRIPTION
This commit adds GitHub actions (there wasn't a setup.py yet, so I've added a Jupyter book instead).
To preview it, please enable in GitHub settings GitHub pages for `gh-pages` branch like in the attached screenshot. There should be a gh page on https://dataresponsibly.github.io/SynRD.
If you wouldn't like the GH pages I'll remove it :)
Also, as soon as there would be a `setup.py` I'll start working on GH actions for it.
![image](https://user-images.githubusercontent.com/40110937/197961431-8fcb93a3-1e10-45a8-9213-97ef9f8c2b93.png)
